### PR TITLE
Change default value in enabled to 1 rather than on

### DIFF
--- a/migrations/2015_03_20_171947_anomaly.module.pages__1_0_0__create_pages_fields.php
+++ b/migrations/2015_03_20_171947_anomaly.module.pages__1_0_0__create_pages_fields.php
@@ -28,7 +28,7 @@ class AnomalyModulePages_1_0_0_CreatePagesFields extends Migration
         'enabled'          => [
             'type'   => 'anomaly.field_type.boolean',
             'config' => [
-                'default_value' => '1',
+                'default_value' => true,
             ]
         ],
         'meta_title'       => 'anomaly.field_type.text',

--- a/migrations/2015_03_20_171947_anomaly.module.pages__1_0_0__create_pages_fields.php
+++ b/migrations/2015_03_20_171947_anomaly.module.pages__1_0_0__create_pages_fields.php
@@ -28,7 +28,7 @@ class AnomalyModulePages_1_0_0_CreatePagesFields extends Migration
         'enabled'          => [
             'type'   => 'anomaly.field_type.boolean',
             'config' => [
-                'default_value' => 'on',
+                'default_value' => '1',
             ]
         ],
         'meta_title'       => 'anomaly.field_type.text',


### PR DESCRIPTION
@RyanThompson I'm not sure if this is the route that you want to go, but when trying to install the pages module the migration was trying to set 'on' as the default value directly in the database. This allows the module to be installed, but it might be an underlying issue that you want to look at. Rather than just saying "I had another issue" I wanted to at least submit a fix that does make it work. Feel free to reject in favor of another solution.
