### PR TITLE
Add a redirect route to the home page slug that redirects back to root.

### DIFF
--- a/resources/assets/routes.stub
+++ b/resources/assets/routes.stub
@@ -3,6 +3,6 @@
 {% for page in pages %}
 Route::any('{{ loop.first ? '/' : page.path() }}', ['uses' => 'Anomaly\PagesModule\Http\Controller\PagesController@view', 'id' => {{ page.id }}]);
 {% if loop.first %}
-Route::any('{{ page.path() }}', function() { return Redirect::to('/'); } );
+Route::any('{{ page.path() }}', ['uses' => 'Anomaly\PagesModule\Http\Controller\PagesController@redirectHome']);
 {% endif %}
 {% endfor %}

--- a/resources/assets/routes.stub
+++ b/resources/assets/routes.stub
@@ -2,4 +2,7 @@
 
 {% for page in pages %}
 Route::any('{{ loop.first ? '/' : page.path() }}', ['uses' => 'Anomaly\PagesModule\Http\Controller\PagesController@view', 'id' => {{ page.id }}]);
+{% if loop.first %}
+Route::any('{{ page.path() }}', function() { return Redirect::to('/'); } );
+{% endif %}
 {% endfor %}

--- a/src/Http/Controller/PagesController.php
+++ b/src/Http/Controller/PagesController.php
@@ -92,6 +92,8 @@ class PagesController extends PublicController
 
     /**
      * The home page slug should redirect to the root /
+     *
+     * @return RedirectResponse
      */
     public function redirectHome()
     {

--- a/src/Http/Controller/PagesController.php
+++ b/src/Http/Controller/PagesController.php
@@ -91,6 +91,14 @@ class PagesController extends PublicController
     }
 
     /**
+     * The home page slug should redirect to the root /
+     */
+    public function redirectHome()
+    {
+        return redirect('/');
+    }
+
+    /**
      * View a page.
      *
      * @return Response


### PR DESCRIPTION
This is the way that Pyro 2 worked and it worked pretty well. I just noticed this when I was writing the page_link_type-extension and the home page, although it had a slug, when the slug was referenced it would 404.
