### PR TITLE
Sort pages in descending order

### DIFF
--- a/src/PagesModuleServiceProvider.php
+++ b/src/PagesModuleServiceProvider.php
@@ -94,7 +94,7 @@ class PagesModuleServiceProvider extends AddonServiceProvider
         }
 
         /* @var PageCollection $pages */
-        $pages = $pages->sorted();
+        $pages = $pages->sorted('desc');
 
         /* @var PageInterface $page */
         foreach ($pages as $page) {


### PR DESCRIPTION
Sort pages in descending order to float longer paths to the top.
This fixes a bug where a child non-exact page is never reachable if it's
parent is also non-exact.