### PR TITLE
Fix preview authorisation, correct permission and add to lang file

### DIFF
--- a/resources/config/permissions.php
+++ b/resources/config/permissions.php
@@ -5,6 +5,7 @@ return [
         'read',
         'write',
         'delete',
+        'preview'
     ],
     'types'  => [
         'read',

--- a/resources/lang/en/permission.php
+++ b/resources/lang/en/permission.php
@@ -7,6 +7,7 @@ return [
             'read'   => 'Can read pages?',
             'write'  => 'Can write pages?',
             'delete' => 'Can delete pages?',
+            'preview' => 'Can preview pages?'
         ],
     ],
     'types'  => [

--- a/src/Http/Controller/PagesController.php
+++ b/src/Http/Controller/PagesController.php
@@ -59,6 +59,7 @@ class PagesController extends PublicController
         }
 
         $page->setAttribute('enabled', true);
+        $page->setPreview(true);
 
         $type    = $page->getType();
         $handler = $type->getHandler();

--- a/src/Page/Contract/PageInterface.php
+++ b/src/Page/Contract/PageInterface.php
@@ -252,4 +252,19 @@ interface PageInterface extends EntryInterface
      * @return HasMany
      */
     public function siblings();
+
+    /**
+     * Get the preview flag.
+     *
+     * @return bool
+     */
+    public function isPreview();
+
+    /**
+     * Set the preview flag.
+     *
+     * @param $preview
+     * @return $this
+     */
+    public function setPreview($preview);
 }

--- a/src/Page/PageAuthorizer.php
+++ b/src/Page/PageAuthorizer.php
@@ -72,18 +72,18 @@ class PageAuthorizer
         $user = $this->guard->user();
 
         /*
-         * If the page is not enabled and we
+         * If the page is not enabled or is a preview and we
          * are not logged in then 404.
          */
-        if (!$page->isEnabled() && !$user) {
+        if ((!$page->isEnabled() || $page->isPreview()) && !$user) {
             abort(404);
         }
 
         /*
-         * If the page is not enabled and we are
+         * If the page is enabled and is a preview and we are
          * logged in then make sure we have permission.
          */
-        if (!$page->isEnabled() && !$this->authorizer->authorize('anomaly.module.pages::view_drafts')) {
+        if ($page->isEnabled() && $page->isPreview() && !$this->authorizer->authorize('anomaly.module.pages::pages.preview')) {
             abort(403);
         }
 

--- a/src/Page/PageModel.php
+++ b/src/Page/PageModel.php
@@ -453,4 +453,25 @@ class PageModel extends PagesPagesEntryModel implements PageInterface
 
         return $array;
     }
+
+    /**
+     * Set the preview flag.
+     *
+     * @param $preview
+     * @return $this
+     */
+    public function setPreview($preview)
+    {
+        $this->preview = $preview;
+
+        return $this;
+    }
+
+    /**
+     * Get the preview flag.
+     */
+    public function isPreview()
+    {
+        return $this->preview;
+    }
 }


### PR DESCRIPTION
This fixes a bug with disabled pages still being accessible via the preview route even when logged out / not authorised. It also adds the permission correctly to the config file for use in CP permissions section.