### PR TITLE
Fixed max length of the slug

### DIFF
--- a/migrations/2015_04_22_150211_anomaly.module.pages__create_types_stream.php
+++ b/migrations/2015_04_22_150211_anomaly.module.pages__create_types_stream.php
@@ -36,7 +36,7 @@ class AnomalyModulePagesCreateTypesStream extends Migration
             'required'     => true,
             'unique'       => true,
             'config'       => [
-                'max' => 50,
+                'max' => 26,
             ],
         ],
         'slug'         => [
@@ -45,7 +45,7 @@ class AnomalyModulePagesCreateTypesStream extends Migration
             'config'   => [
                 'slugify' => 'name',
                 'type'    => '_',
-                'max'     => 50,
+                'max'     => 26,
             ],
         ],
         'description'  => [


### PR DESCRIPTION
Unfortunately, 27 symbols are causing exception of too long index in DB.