### PR TITLE
Allow fallback translation for page path

### DIFF
--- a/src/Page/Command/SetPath.php
+++ b/src/Page/Command/SetPath.php
@@ -40,8 +40,8 @@ class SetPath
 
         if ($parent = $page->getParent()) {
             $path = ($parent->isHome()
-                    ? $parent->translate($this->translation->getLocale())->slug
-                    : $parent->translate($this->translation->getLocale())->path
+                    ? $parent->translate($this->translation->getLocale(), true)->slug
+                    : $parent->translate($this->translation->getLocale(), true)->path
                 ) . '/' . $this->translation->slug;
         } elseif ($page->isHome()) {
             $path = '/';


### PR DESCRIPTION
Currenty, if a new language is enabled, the pages module will break and refuse to save child pages when their parents don't have a translations entry for the new language. This PR adds the ability to fallback to the default language.